### PR TITLE
⚡ Optimize Object.keys computation in updateSubtitle

### DIFF
--- a/script.js
+++ b/script.js
@@ -71,10 +71,11 @@ document.addEventListener('DOMContentLoaded', function() {
         return words[Math.floor(Math.random() * words.length)];
     }    
 
+    const categories = Object.keys(wordCategories);
+
     function updateSubtitle() {
         const subtitleElement = document.querySelector('.lead');
         if (subtitleElement) {
-            const categories = Object.keys(wordCategories);
             // Shuffle categories to get a random mix
             const shuffledCategories = categories.sort(() => 0.5 - Math.random());
             const selectedCategories = shuffledCategories.slice(0, 3);


### PR DESCRIPTION
💡 **What:** Moved `Object.keys(wordCategories)` outside of the `updateSubtitle` interval function to compute it only once.
🎯 **Why:** `wordCategories` is a static object, so extracting its keys repeatedly within the `setInterval` loop introduces redundant micro-computations. Caching it eliminates this small overhead.
📊 **Measured Improvement:** As per instructions from the user to skip profiling/benchmarking for this micro-optimization, no specific metrics are included.

---
*PR created automatically by Jules for task [11942177413209478456](https://jules.google.com/task/11942177413209478456) started by @Abish4i*