### PR TITLE
🔒 Sanitize repository URL to prevent XSS in portfolio

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -61,7 +61,7 @@
               <p>${escapeHtml(repo.description || repo.language || '')}</p>
             </div>
             <div class="buttons" style="margin-top: 1rem;">
-              <a class="btn" href="${repo.html_url}" target="_blank" rel="noopener">View Project</a>
+              <a class="btn" href="${escapeHtml(String(repo.html_url).startsWith('https://') ? repo.html_url : '#')}" target="_blank" rel="noopener">View Project</a>
             </div>
           `;
                     container.appendChild(el);


### PR DESCRIPTION
🎯 What: Fixed an unsanitized input vulnerability in the `href` attribute for repository links in `portfolio.html`.
⚠️ Risk: If the GitHub API response contained malicious payloads (e.g., `javascript:` URLs or HTML injection) in the `html_url` field, it could lead to Cross-Site Scripting (XSS) when a user clicked the 'View Project' button.
🛡️ Solution: Validated that the `html_url` explicitly starts with `https://` (falling back to `#`) and wrapped the result in the existing `escapeHtml()` function to fully mitigate potential injection attacks.

---
*PR created automatically by Jules for task [4216334357690413684](https://jules.google.com/task/4216334357690413684) started by @Abish4i*